### PR TITLE
Add Tailwind CSS support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.16"
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,jsx,ts,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- install Tailwind CSS with PostCSS and Autoprefixer
- add a basic Tailwind config
- load Tailwind directives in `index.css`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6851eb08c76c8326b216bbb089ac49a8