### PR TITLE
Add redirect handlers and copy legal pages

### DIFF
--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Privacy Policy – BukMe</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>Privacy Policy</h1>
+    <p>Effective Date: May 31, 2025</p>
+
+    <p><strong>BukMe</strong> ("we", "our", or "us") is committed to protecting your privacy. This Privacy Policy explains how we collect, use, and share your personal information when you use our app or visit our website.</p>
+
+    <h2>Information We Collect</h2>
+    <ul>
+      <li><strong>Account Info:</strong> Name, email address, profile photo, and identity verification details.</li>
+      <li><strong>Location Data:</strong> We collect GPS coordinates at the time of booking and check-in to ensure safe in-person interactions.</li>
+      <li><strong>Payment Info:</strong> All payments are processed securely via Stripe. We do not store credit card details on our servers.</li>
+      <li><strong>Usage Data:</strong> We collect anonymized data about app interactions, including time, date, and actions taken for security and performance improvements.</li>
+    </ul>
+
+    <h2>How We Use Your Information</h2>
+    <ul>
+      <li>To facilitate bookings between buyers and sellers</li>
+      <li>To verify identity and reduce fraud</li>
+      <li>To provide customer support and resolve disputes</li>
+      <li>To comply with legal obligations</li>
+    </ul>
+
+    <h2>Third-Party Services</h2>
+    <p>We use the following third-party services, which may collect your data according to their privacy policies:</p>
+    <ul>
+      <li><a href="https://stripe.com/privacy" target="_blank">Stripe</a> – for payments and identity verification</li>
+      <li><a href="https://firebase.google.com/support/privacy" target="_blank">Firebase</a> – for backend authentication and database</li>
+      <li><a href="https://expo.dev/privacy" target="_blank">Expo</a> – for mobile development platform</li>
+    </ul>
+
+    <h2>Your Rights</h2>
+    <p>You have the right to access, update, or delete your personal information. You may do so by contacting us at <a href="mailto:tismyaka@gmail.com">tismyaka@gmail.com</a>.</p>
+
+    <h2>Data Security</h2>
+    <p>We implement appropriate safeguards such as encryption, access control, and secure hosting to protect your personal data.</p>
+
+    <h2>Children's Privacy</h2>
+    <p>BukMe is not intended for children under 13. We do not knowingly collect personal information from children.</p>
+
+    <h2>Changes to This Policy</h2>
+    <p>We may update this policy at any time. Changes will be posted on this page with a revised effective date.</p>
+
+    <p>If you have questions or concerns about this Privacy Policy, please contact us at <a href="mailto:tismyaka@gmail.com">tismyaka@gmail.com</a>.</p>
+  </div>
+</body>
+</html>

--- a/public/stripe/refresh.html
+++ b/public/stripe/refresh.html
@@ -1,0 +1,1 @@
+<script>location.href='/stripe-onboarding';</script>

--- a/public/stripe/return.html
+++ b/public/stripe/return.html
@@ -1,0 +1,1 @@
+<script>location.href='/dashboard';</script>

--- a/public/terms.html
+++ b/public/terms.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Terms of Service – BukMe</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>Terms of Service</h1>
+    <p>Effective Date: May 31, 2025</p>
+
+    <h2>1. Acceptance of Terms</h2>
+    <p>By using BukMe, you agree to be bound by these Terms of Service and our Privacy Policy. If you do not agree, please do not use the app.</p>
+
+    <h2>2. Account Responsibilities</h2>
+    <p>You are responsible for maintaining the confidentiality of your account credentials. You agree not to impersonate others or create multiple accounts for the same role (buyer/seller).</p>
+
+    <h2>3. Booking and Payment</h2>
+    <ul>
+      <li>All bookings must be confirmed by both parties.</li>
+      <li>Funds are held in escrow via Stripe until the booking is marked complete and verified.</li>
+      <li>BukMe is not a party to the agreement between buyer and seller but provides the platform to facilitate it.</li>
+    </ul>
+
+    <h2>4. Cancellation & Disputes</h2>
+    <p>Buyers may cancel within 24 hours of booking unless the booking is on the same day. Sellers and buyers may flag a dispute for admin review within 48 hours after the appointment.</p>
+
+    <h2>5. User Conduct</h2>
+    <p>All users must behave professionally and legally. BukMe reserves the right to suspend or ban accounts involved in abuse, fraud, harassment, or illegal activity.</p>
+
+    <h2>6. Verification</h2>
+    <p>First-time users may be required to complete identity verification through Stripe. We reserve the right to deny access if verification is not completed.</p>
+
+    <h2>7. Limitation of Liability</h2>
+    <p>BukMe is not responsible for injuries, damages, or legal issues resulting from in-person or remote interactions between users. Use the platform at your own risk.</p>
+
+    <h2>8. Modifications</h2>
+    <p>We may update these Terms of Service from time to time. Continued use of the platform implies acceptance of the updated terms.</p>
+
+    <h2>9. Contact</h2>
+    <p>If you have questions, contact us at <a href="mailto:tismyaka@gmail.com">tismyaka@gmail.com</a>.</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add redirect pages for Stripe onboarding flow
- copy privacy and terms pages into `public`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6851eb0171e8832699ff310ebc0ee96a